### PR TITLE
Upgrade to support Mongo 2 driver

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,38 +4,40 @@
 
 > The purpose of this module is to manage mongo connection pools without creating a new connection pool in every file.
 >
-> You can require this module in as many files as you want and every time you call `mongoFactory.getConnection`, it returns
+> You can require this module in as many files as you want and every time you call `mongoFactory.getConnection` it returns
 > a connection if one exists for the connection string passed in, or it instantiates the connection pool and
 > then returns a connection.
 
-##Usage
+## Usage
 
 ```js
 var mongoFactory = require('mongo-factory');
 
-mongoFactory.getConnection('mongodb://localhost:27017').then(function(db) {
-	// user "db" as you normally would
-	db.collection.find()....
-}).fail(function(err) {
-	console.log(err);
-});
+mongoFactory.getConnection('mongodb://localhost:27017')
+  .then(function(db) {
+    // Use mongo's "db" object as you normally would.
+    db.collection.find()...
+  })
+  .catch(function(err) {
+    console.error(err);
+  });
 ```
 
-##API
+## API
 
-#### `getConnection(mongodbConnectionString)` 
-- The only parameter being a connection string for a mongodb connection.
+#### `getConnection(mongodbConnectionString)`
 
-#### `ObjectId` 
-- Exposes the mongodb [ObjectID](http://mongodb.github.io/node-mongodb-native/2.0/tutorials/objectid/) function.
+The only parameter is a connection string for a MongoDB connection.
 
-##Contributing
+#### `ObjectId`
+
+Exposes the MongoDB [ObjectID](http://mongodb.github.io/node-mongodb-native/2.0/tutorials/objectid/) function.
+
+## Contributing
 
 1. Clone project and run `npm install`
-2. Add feature(s) 
+2. Add feature(s)
 3. Add tests for it
 4. Submit pull request
 
 Enjoy!
-
-

--- a/index.js
+++ b/index.js
@@ -31,26 +31,25 @@ module.exports = function() {
         // Check if connections contains an object with connectionString equal to the connectionString passed in and set the var to it
         var pool = _.findWhere(connections, {connectionString: connectionString});
 
-        // If no conneciton pool has been instantiated, instantiate it, else return a connection from the pool
-        if(_.isUndefined(pool)) {
-
-          // Initialize connection once
-          MongoClient.connect(connectionString, function(err, database) {
-
-            if (err) {
-              reject(err);
-            }
-
-            // Add the connection to the array
-            connections.push({connectionString: connectionString, db: database});
-
-            resolve(database);
-          });
-
-        } else {  // Else we have not instantiated the pool yet and we need to
-          resolve(pool.db);
+        // If a connection pool was found, resolve the promise with it.
+        if (pool) {
+          return resolve(pool.db);
         }
 
+        // If no conneciton pool has been instantiated, instantiate it, else return a connection from the pool
+        MongoClient.connect(connectionString, function(err, database) {
+          if (err) {
+            return reject(err);
+          }
+
+          // Add the connection to the array
+          connections.push({
+            connectionString: connectionString,
+            db: database
+          });
+
+          return resolve(database);
+        });
       });
     },
 

--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ var mongo = require('mongodb');
 var MongoClient = mongo.MongoClient;
 var _ = require('underscore');
 
+// Store all instantiated connections.
 var connections = [];
 
 module.exports = function() {
@@ -15,34 +16,36 @@ module.exports = function() {
   return {
 
     /**
-     * Gets a connection to Mongo from the pool. If the pool has not been instantiated it,
-     *    instantiates it and returns a connection. Else it just returns a connection from the pool
+     * Gets a Mongo connection from the pool.
      *
-     * @returns {*}   - A promise object that will resolve to a mongo db object
+     * If the connection pool has not been instantiated yet, it is first
+     * instantiated and a connection is returned.
+     *
+     * @returns {Promise|Db} - A promise object that resolves to a Mongo db object.
      */
     getConnection: function getConnection(connectionString) {
       return new Promise(function(resolve, reject) {
-
-        // If connectionString is null or undefined, return an error
-        if(_.isEmpty(connectionString)) {
+        // If connectionString is null or undefined, return an error.
+        if (_.isEmpty(connectionString)) {
           return reject('getConnection must be called with a mongo connection string');
         }
 
-        // Check if connections contains an object with connectionString equal to the connectionString passed in and set the var to it
-        var pool = _.findWhere(connections, {connectionString: connectionString});
+        // Check if a connection already exists for the provided connectionString.
+        var pool = _.findWhere(connections, { connectionString: connectionString });
 
         // If a connection pool was found, resolve the promise with it.
         if (pool) {
           return resolve(pool.db);
         }
 
-        // If no conneciton pool has been instantiated, instantiate it, else return a connection from the pool
+        // If the connection pool has not been instantiated,
+        // instantiate it and return the connection.
         MongoClient.connect(connectionString, function(err, database) {
           if (err) {
             return reject(err);
           }
 
-          // Add the connection to the array
+          // Store the connection in the connections array.
           connections.push({
             connectionString: connectionString,
             db: database
@@ -54,9 +57,9 @@ module.exports = function() {
     },
 
     /**
-     * Exposes mongodb's ObjectID function
+     * Exposes Mongo ObjectID function.
      *
-     * @returns  - Mongodb's ObjectID function
+     * @returns {Function} - Mongo ObjectID function
      */
     ObjectID: function() {
       return mongo.ObjectID();

--- a/package.json
+++ b/package.json
@@ -24,8 +24,10 @@
   "homepage": "https://github.com/toymachiner62/mongoFactory",
   "dependencies": {
     "q": "^1.0.1",
-    "mongodb": "^1.4.9",
     "underscore": "^1.7.0"
+  },
+  "peerDependencies": {
+    "mongodb": "*"
   },
   "devDependencies": {
     "chai": "^3.4.1",

--- a/package.json
+++ b/package.json
@@ -28,10 +28,10 @@
     "underscore": "^1.7.0"
   },
   "devDependencies": {
-    "chai": "^1.9.1",
-    "chai-as-promised": "^4.1.1",
-    "chai-spies": "^0.5.1",
-    "codeclimate-test-reporter": "0.0.3",
-    "mocha": "^1.21.4"
+    "chai": "^3.4.1",
+    "chai-as-promised": "^5.2.0",
+    "chai-spies": "^0.7.1",
+    "codeclimate-test-reporter": "0.1.1",
+    "mocha": "^2.3.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "homepage": "https://github.com/toymachiner62/mongoFactory",
   "dependencies": {
     "es6-promise": "^3.0.2",
-    "underscore": "^1.7.0"
+    "underscore": "^1.8.3"
   },
   "peerDependencies": {
     "mongodb": "*"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "homepage": "https://github.com/toymachiner62/mongoFactory",
   "dependencies": {
-    "q": "^1.0.1",
+    "es6-promise": "^3.0.2",
     "underscore": "^1.7.0"
   },
   "peerDependencies": {

--- a/test/test.js
+++ b/test/test.js
@@ -3,41 +3,37 @@ var expect = chai.expect;
 var mongo = require('mongodb');
 
 describe('mongoFactory', function() {
-
   var mongoFactory;
 
   beforeEach(function() {
     mongoFactory = require('../');
   });
 
-  it('can be required without blowing up', function() {
+  it('can be required without blowing up', function(done) {
     var mongoFactory = require('../');
     expect(mongoFactory).to.exist;
+    done();
   });
 
   describe('getConnection()', function() {
-
-    describe('with no arguments passed in', function() {
+    describe('with no parameters', function() {
       it('should fulfill the promise', function(done) {
-        // var mongoFactory = require('../');
-        var con = mongoFactory.getConnection();
-        expect(con).to.be.fulfilled;
+        var conn = mongoFactory.getConnection();
+        expect(conn).to.be.fulfilled;
         done();
       });
 
-      it('should return a rejected promise', function(done) {
-        // var mongoFactory = require('../');
-        var con = mongoFactory.getConnection();
-        expect(con).to.be.rejected;
+      it('should reject the promise', function(done) {
+        var conn = mongoFactory.getConnection();
+        expect(conn).to.be.rejected;
         done();
       });
      });
 
     describe('with a null parameter', function() {
-      it('should return a rejected promise', function(done) {
-        // var mongoFactory = require('../');
-        var con = mongoFactory.getConnection(null);
-        expect(con).to.be.rejected;
+      it('should reject the promise', function(done) {
+        var conn = mongoFactory.getConnection(null);
+        expect(conn).to.be.rejected;
         done();
       });
     });
@@ -45,9 +41,9 @@ describe('mongoFactory', function() {
     describe('with a valid mongo string parameter', function() {
       describe('needing to create the pool the first time', function() {
         it('should return a fulfilled promise', function(done) {
-          var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function(db) {
-            expect(con).to.be.fulfilled;
-            expect(con).to.not.be.rejected;
+          var conn = mongoFactory.getConnection('mongodb://localhost:27017').then(function(db) {
+            expect(conn).to.be.fulfilled;
+            expect(conn).to.not.be.rejected;
             done();
           });
         });
@@ -55,10 +51,10 @@ describe('mongoFactory', function() {
 
       describe('after a pool is already instantiated', function() {
         it('should return a fulfilled promise', function(done) {
-          var con1 = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
-            var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
-              expect(con).to.be.fulfilled;
-              expect(con).to.not.be.rejected;
+          var conn1 = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
+            var conn = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
+              expect(conn).to.be.fulfilled;
+              expect(conn).to.not.be.rejected;
               done();
             });
           });
@@ -78,7 +74,7 @@ describe('mongoFactory', function() {
       expect(oid.toHexString().length).to.equal(24);
     });
 
-    it('should allow you to compare ObjectID\'s', function() {
+    it('should allow you to compare ObjectIDs', function() {
       var oid1 = new mongoFactory.ObjectID;
       var oid2 = new mongoFactory.ObjectID(oid1.id);
       var oid3 = new mongoFactory.ObjectID;
@@ -94,6 +90,5 @@ describe('mongoFactory', function() {
       var oid = new mongoFactory.ObjectID(timestamp);
       expect(oid.getTimestamp().toString()).to.equal(timestampDate.toString());
     });
-
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -67,7 +67,7 @@ describe('mongoFactory', function() {
 		});
 	});
 
-	describe.only('ObjectID', function() {
+	describe('ObjectID', function() {
 		it('should return mongo\'s ObjectID method', function() {
 			var oid = mongoFactory.ObjectID;
 			expect(oid).to.be.a.function;

--- a/test/test.js
+++ b/test/test.js
@@ -4,96 +4,96 @@ var mongo = require('mongodb');
 
 describe('mongoFactory', function() {
 
-	var mongoFactory;
-		
-	beforeEach(function() {
-		mongoFactory = require('../');
-	});
-	
-	it('can be required without blowing up', function() {
-		var mongoFactory = require('../');
-		expect(mongoFactory).to.exist;
-	});
-	
-	describe('getConnection()', function() {
-		
-		describe('with no arguments passed in', function() {
-			it('should fulfill the promise', function(done) {
-				//var mongoFactory = require('../');
-				var con = mongoFactory.getConnection();
-				expect(con).to.be.fulfilled;
-				done();
-			});
-			
-			it('should return a rejected promise', function(done) {
-				//var mongoFactory = require('../');
-				var con = mongoFactory.getConnection();
-				expect(con).to.be.rejected;
-				done();
-			});
- 		});
-		
-		describe('with a null parameter', function() {
-			it('should return a rejected promise', function(done) {
-				//var mongoFactory = require('../');
-				var con = mongoFactory.getConnection(null);
-				expect(con).to.be.rejected;
-				done();
-			});
-		});
-		
-		describe('with a valid mongo string parameter', function() {
-			describe('needing to create the pool the first time', function() {
-				it('should return a fulfilled promise', function(done) {
-					var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function(db) {
-						expect(con).to.be.fulfilled;
-						expect(con).to.not.be.rejected;
-						done();
-					});
-				});
-			});
-			
-			describe('after a pool is already instantiated', function() {
-				it('should return a fulfilled promise', function(done) {
-					var con1 = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
-						var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
-							expect(con).to.be.fulfilled;
-							expect(con).to.not.be.rejected;
-							done();
-						});
-					});
-				});
-			});
-		});
-	});
+  var mongoFactory;
 
-	describe('ObjectID', function() {
-		it('should return mongo\'s ObjectID method', function() {
-			var oid = mongoFactory.ObjectID;
-			expect(oid).to.be.a.function;
-		});
+  beforeEach(function() {
+    mongoFactory = require('../');
+  });
 
-		it('should allow you to create a new ObjectID', function() {
-			var oid = new mongoFactory.ObjectID;
-			expect(oid.toHexString().length).to.equal(24);
-		});
+  it('can be required without blowing up', function() {
+    var mongoFactory = require('../');
+    expect(mongoFactory).to.exist;
+  });
 
-		it('should allow you to compare ObjectID\'s', function() {
-			var oid1 = new mongoFactory.ObjectID;
-			var oid2 = new mongoFactory.ObjectID(oid1.id);
-			var oid3 = new mongoFactory.ObjectID;
-			expect(oid1.equals(oid2));
-			expect(!oid1.equals(oid3));
-		});
+  describe('getConnection()', function() {
 
-		it('should allow you to create a new ObjectID with a specific timestamp', function() {
-			// Get a timestamp in seconds
-			var timestamp = Math.floor(new Date().getTime()/1000);
-			// Create a date with the timestamp
-			var timestampDate = new Date(timestamp*1000);
-			var oid = new mongoFactory.ObjectID(timestamp);
-			expect(oid.getTimestamp().toString()).to.equal(timestampDate.toString());
-		});
+    describe('with no arguments passed in', function() {
+      it('should fulfill the promise', function(done) {
+        // var mongoFactory = require('../');
+        var con = mongoFactory.getConnection();
+        expect(con).to.be.fulfilled;
+        done();
+      });
 
-	});
+      it('should return a rejected promise', function(done) {
+        // var mongoFactory = require('../');
+        var con = mongoFactory.getConnection();
+        expect(con).to.be.rejected;
+        done();
+      });
+     });
+
+    describe('with a null parameter', function() {
+      it('should return a rejected promise', function(done) {
+        // var mongoFactory = require('../');
+        var con = mongoFactory.getConnection(null);
+        expect(con).to.be.rejected;
+        done();
+      });
+    });
+
+    describe('with a valid mongo string parameter', function() {
+      describe('needing to create the pool the first time', function() {
+        it('should return a fulfilled promise', function(done) {
+          var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function(db) {
+            expect(con).to.be.fulfilled;
+            expect(con).to.not.be.rejected;
+            done();
+          });
+        });
+      });
+
+      describe('after a pool is already instantiated', function() {
+        it('should return a fulfilled promise', function(done) {
+          var con1 = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
+            var con = mongoFactory.getConnection('mongodb://localhost:27017').then(function() {
+              expect(con).to.be.fulfilled;
+              expect(con).to.not.be.rejected;
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+
+  describe('ObjectID', function() {
+    it('should return mongo\'s ObjectID method', function() {
+      var oid = mongoFactory.ObjectID;
+      expect(oid).to.be.a.function;
+    });
+
+    it('should allow you to create a new ObjectID', function() {
+      var oid = new mongoFactory.ObjectID;
+      expect(oid.toHexString().length).to.equal(24);
+    });
+
+    it('should allow you to compare ObjectID\'s', function() {
+      var oid1 = new mongoFactory.ObjectID;
+      var oid2 = new mongoFactory.ObjectID(oid1.id);
+      var oid3 = new mongoFactory.ObjectID;
+      expect(oid1.equals(oid2));
+      expect(!oid1.equals(oid3));
+    });
+
+    it('should allow you to create a new ObjectID with a specific timestamp', function() {
+      // Get a timestamp in seconds
+      var timestamp = Math.floor(new Date().getTime()/1000);
+      // Create a date with the timestamp
+      var timestampDate = new Date(timestamp*1000);
+      var oid = new mongoFactory.ObjectID(timestamp);
+      expect(oid.getTimestamp().toString()).to.equal(timestampDate.toString());
+    });
+
+  });
 });


### PR DESCRIPTION
Currently this module forces use of v1.4.x of the Mongo node driver. This update converts mongo to a peer dependency in order to use whatever version the user already has installed.

When testing/developing this module, you'll need to manually install mongo. This has been tested with both v1 (`npm install mongo@1`) and v2 (`npm install mongo@2`).

(This also switches from using Q to native ES6 promises with a polyfill.)
